### PR TITLE
Added TopicsMessageRateExceededError error

### DIFF
--- a/lib/fcm.js
+++ b/lib/fcm.js
@@ -96,6 +96,8 @@ function FCM(serverKey) {
                         id = data.substring(0).trim();
                     } else if (data.indexOf('Unauthorized') > -1) {
                         error = 'NotAuthorizedError'
+                    } else if (data.indexOf('TOPICS_MESSAGE_RATE_EXCEEDED') > -1) {
+                        error = 'TopicsMessageRateExceededError'
                     } else if(data.indexOf('\"message_id\":')>-1){  //topic messages success
                         id=data;
                     }else {


### PR DESCRIPTION
Added TOPICS_MESSAGE_RATE_EXCEEDED to valid server responses, so we return TopicsMessageRateExceededError instead of InvalidServerResponse.